### PR TITLE
Genesis sub-command support added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - `gm nuke` will only restart a node if it was running before the command execution. (Stopped nodes will stay stopped.)
 - "network not found" error if get_network was called with a validator node.
+- `genesis` subcommand introduced in cosmos-sdk v0.47 is now supported ([#7]).
+
+[#7]: https://github.com/informalsystems/gm/issues/7
 
 ### FEATURES
 

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -512,7 +512,7 @@ get_chain_id() {
 # Returns empty string if long is not supported
 get_sdk_version() {
   GAIAD_BINARY="$(get_gaiad_binary "$1")"
-  RESULT="$("$GAIAD_BINARY" version --long | grep "cosmos_sdk_version" | awk '{print $2}' | cut -c 2-)"
+  RESULT="$("$GAIAD_BINARY" version --long | sed -n '/cosmos_sdk_version/ s/cosmos_sdk_version: v\(.*\)$/\1/p')"
   echo "$RESULT"
 }
 

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -251,9 +251,6 @@ enforce_requirements() {
   if [ -z "$(which dirname || echo)" ]; then
     exit_with_error "missing dirname, please install it"
   fi
-  if [ -z "$(which head || echo)" ]; then
-    exit_with_error "missing head, please install it"
-  fi
   STOML="$(which stoml || echo)"
   if [ -z "$STOML" ]; then
     exit_with_error "missing stoml, install it from https://github.com/freshautomations/stoml/releases"
@@ -268,7 +265,7 @@ enforce_requirements() {
   if [ -z "$(which sort || echo)" ]; then
     exit_with_error "missing sort, please install it"
   fi
-  if ! test "$(echo "a\nb" | sort -Vr | head -1)" = "b"; then
+  if ! test "$(echo "a\nb" | sort -Vr | sed -n '1p')" = "b"; then
     exit_with_error "missing sort -V, please install a newer version of sort"
   fi
 }

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -522,7 +522,7 @@ get_genesis_cmd_prefix() {
       GAIAD_BINARY="$(get_gaiad_binary "$1")"
       RESULT="$($GAIAD_BINARY | grep -q 'gentx' || echo "genesis")"
     else
-      HIGHER_VERSION=$(echo "${GENESIS_BREAKING_VERSION}\n${SDK_VERSION}" | sort -Vr | head -1)
+      HIGHER_VERSION=$(echo "${GENESIS_BREAKING_VERSION}\n${SDK_VERSION}" | sort -Vr | sed -n '1p')
       if [ "$HIGHER_VERSION" = "$SDK_VERSION" ]; then
         # Perform actions for the >= 0.47.0 case here
         RESULT="genesis"

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -509,7 +509,7 @@ get_chain_id() {
 # Returns empty string if --long is not supported
 get_sdk_version() {
   GAIAD_BINARY="$(get_gaiad_binary "$1")"
-  RESULT="$("$GAIAD_BINARY" version --long | sed -n '/cosmos_sdk_version/ s/cosmos_sdk_version: v\(.*\)$/\1/p')"
+  RESULT="$("$GAIAD_BINARY" version --long 2>&1 | sed -n '/cosmos_sdk_version/ s/cosmos_sdk_version: v\(.*\)$/\1/p')"
   echo "$RESULT"
 }
 

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -251,6 +251,9 @@ enforce_requirements() {
   if [ -z "$(which dirname || echo)" ]; then
     exit_with_error "missing dirname, please install it"
   fi
+  if [ -z "$(which head || echo)" ]; then
+    exit_with_error "missing head, please install it"
+  fi
   STOML="$(which stoml || echo)"
   if [ -z "$STOML" ]; then
     exit_with_error "missing stoml, install it from https://github.com/freshautomations/stoml/releases"
@@ -261,6 +264,12 @@ enforce_requirements() {
   #PATCH="$(echo "${STOML_VERSION}" | "$SED" "s/^\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)$/\3/")"
   if [ $((MAJOR)) -eq 0 ] && [ $((MINOR)) -lt 7 ]; then
     exit_with_error "stoml too old, install 0.7.0 or newer from https://github.com/freshautomations/stoml/releases"
+  fi
+  if [ -z "$(which sort || echo)" ]; then
+    exit_with_error "missing sort, please install it"
+  fi
+  if ! test "$(echo "a\nb" | sort -Vr | head -1)" = "b"; then
+    exit_with_error "missing sort -V, please install a newer version of sort"
   fi
 }
 

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -515,7 +515,7 @@ get_sdk_version() {
 
 get_genesis_cmd_prefix() {
     GENESIS_BREAKING_VERSION="0.47.0"
-    SDK_VERSION=$(get_sdk_version "$1")
+    SDK_VERSION="$(get_sdk_version "$1")"
     RESULT=""
     if [ -z "$SDK_VERSION" ]; then
       # Handle the sdk version error here, happens when --long is not supported

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -504,11 +504,7 @@ get_chain_id() {
 get_sdk_version() {
   GAIAD_BINARY="$(get_gaiad_binary "$1")"
   RESULT="$("$GAIAD_BINARY" version --long | grep "cosmos_sdk_version" | awk '{print $2}' | cut -c 2-)"
-  if [ -z "$RESULT" ]; then
-    echo ""
-  else
-    echo "$RESULT"
-  fi
+  echo "$RESULT"
 }
 
 get_genesis_cmd_prefix() {

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -506,7 +506,7 @@ get_chain_id() {
   fi
 }
 
-# Returns empty string if long is not supported
+# Returns empty string if --long is not supported
 get_sdk_version() {
   GAIAD_BINARY="$(get_gaiad_binary "$1")"
   RESULT="$("$GAIAD_BINARY" version --long | sed -n '/cosmos_sdk_version/ s/cosmos_sdk_version: v\(.*\)$/\1/p')"

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -657,19 +657,25 @@ create() {
     # Add accounts to genesis
     GENESIS_CMD_PREFIX=$(get_genesis_cmd_prefix "$1")
     DENOM="$(get_staking_denom "$1")"
+    # shellcheck disable=SC2086
     "$GAIAD_BINARY" $GENESIS_CMD_PREFIX add-genesis-account validator "100000000${DENOM},100000000samoleans" --keyring-backend test --home "${HOME_DIR}"
+    # shellcheck disable=SC2086
     "$GAIAD_BINARY" $GENESIS_CMD_PREFIX add-genesis-account wallet "100000000${DENOM},100000000samoleans" --keyring-backend test --home "${HOME_DIR}"
     EXTRA_WALLETS_COUNTER="$(get_extra_wallets "$1")"
     while [ "$EXTRA_WALLETS_COUNTER" -gt 0 ];
     do
+      # shellcheck disable=SC2086
       "$GAIAD_BINARY" $GENESIS_CMD_PREFIX add-genesis-account "wallet${EXTRA_WALLETS_COUNTER}" "100000000${DENOM},100000000samoleans" --keyring-backend test --home "${HOME_DIR}"
       EXTRA_WALLETS_COUNTER="$((EXTRA_WALLETS_COUNTER - 1))"
     done
     # Create gentx
+    # shellcheck disable=SC2086
     "$GAIAD_BINARY" $GENESIS_CMD_PREFIX gentx validator "1000000${DENOM}" --keyring-backend test --keyring-dir "${HOME_DIR}" --home "${HOME_DIR}" --chain-id "$1" 2> /dev/null
     # Collect gentxs
+    # shellcheck disable=SC2086
     "$GAIAD_BINARY" $GENESIS_CMD_PREFIX collect-gentxs --home "${HOME_DIR}" 2> /dev/null
     # Validate genesis
+    # shellcheck disable=SC2086
     "$GAIAD_BINARY" $GENESIS_CMD_PREFIX validate-genesis --home "${HOME_DIR}" > /dev/null
   else
     NETWORK_HOME_DIR="$(get_home_dir "$NETWORK")"
@@ -753,6 +759,7 @@ start() {
     GAIAD_BINARY="$(get_gaiad_binary "$1")"
     HOME_DIR="$(get_home_dir "$1")"
     GAIAD_LOG="${HOME_DIR}/log"
+    # shellcheck disable=SC2086
     VALIDATION="$("$GAIAD_BINARY" $GENESIS_CMD_PREFIX validate-genesis --home "$HOME_DIR" > "$GAIAD_LOG" 2>&1 || echo "ERR")"
     if [ "$VALIDATION" = "ERR" ]; then
       warn "validate-genesis could not complete for ${1}"


### PR DESCRIPTION
## Description

This PR introduces support for the `genesis` sub-command added in CosmosSDK 0.47, addressing an issue that caused binaries built with CosmosSDK 0.47+ to fail when starting in gaid manager.

closes: #7 

## Changes

Two new functions have been added to lib-gm: `get_sdk_version` and `get_genesis_cmd_prefix`.

### `get_sdk_version`

This function retrieves the version of the Cosmos SDK used to build the binary by utilizing the `version --long` sub-command. If `--long` is not supported by the binary, it returns an empty string.

### `get_genesis_cmd_prefix`

This function returns "genesis" if the Cosmos SDK version is `>=0.47.0`. If the Cosmos SDK version is an empty string, it follows a similar strategy used for handling the `tendermint` sub-command, returning "genesis" if "gentx" is not listed as an available sub-command when running the binary. In all other cases, it returns an empty string.

## Commit Message /  Changelog Entry

The `CHANGELOG.md` has been updated accordingly. Maintainer edits are enabled, allowing for easy modifications if there's disagreement with any design choices above. For instance, the `get_sdk_version` command might not be necessary, though it could prove useful in the future, especially if an SDK-version flag is added to the config. No strong preference is held.

Due to trial and error, the number of commits is high. The following commit message is suggested for when this PR is squash merged:

```
fix: added support for the genesis sub-command
```