### PR TITLE
Bugfixes v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Gaiad Manager Change Log
 
+## v0.1.6
+
+### BUGFIXES
+
+- Documented `create-validator` in the help section.
+- When using `create-validator the seed phrase for the validator wallet was not saved.
+- When listing keys that were created using `create-validator`, the validator's key was not found 
+  because it was considered a full node first and full nodes store keys in key_seed.json, not <name>_seed.json.
+
 ## v0.1.5
 
 ### BUGFIXES

--- a/bin/gm
+++ b/bin/gm
@@ -30,23 +30,24 @@ Usage:
 
 COMMANDS    DESCRIPTION
 
-alias       print useful aliases for exec
-exec        execute binary commands on nodes
-explorer    sub-commands for the experimental blockchain explorer
-help        print this help and exit
-hermes      sub-command for hermes-related configuration
-install     install the script for the local user
-keys        print the keys of validator nodes
-log         print the log of a node
-new-wallet  create funded wallet
-nuke        stop one or more nodes, delete their configuration and restart them
-ports       print the ports of a (running) node
-start       start one or more nodes (starts all nodes if no parameter is given)
-status      print the status of nodes
-stop        stop one or more nodes (stops all nodes if no parameter is given)
-reset       reset one or more nodes' database (resets all nodes if no parameter is given)
-rm          delete the configuration of a node
-version     print the application version
+alias            print useful aliases for exec
+create-validator used on a running full-node, it sends a create-validator transaction
+exec             execute binary commands on nodes
+explorer         sub-commands for the experimental blockchain explorer
+help             print this help and exit
+hermes           sub-command for hermes-related configuration
+install          install the script for the local user
+keys             print the keys of validator nodes
+log              print the log of a node
+new-wallet       create funded wallet
+nuke             stop one or more nodes, delete their configuration and restart them
+ports            print the ports of a (running) node
+start            start one or more nodes (starts all nodes if no parameter is given)
+status           print the status of nodes
+stop             stop one or more nodes (stops all nodes if no parameter is given)
+reset            reset one or more nodes' database (resets all nodes if no parameter is given)
+rm               delete the configuration of a node
+version          print the application version
 
 EOF
 }

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -5,7 +5,7 @@ if [ "${DEBUG:-}" = "2" ]; then
 fi
 
 version() {
-  VERSION="v0.1.5"
+  VERSION="v0.1.6"
   if is_json_output; then
     echo '{"status": "success", "message": "'"${VERSION}"'"}'
   else
@@ -969,10 +969,10 @@ list_keys() {
     elif [ "$MNEMONIC" != "$line" ]; then
       if a_in_b "${KEY_NAME%%v0}" "$VALIDATORS"; then
         echo "mnemonic: \"$(stoml "${HOME_DIR}/key_seed.json" secret)\""
-      elif a_in_b "${KEY_NAME%%n0}" "$FULL_NODES"; then
-        echo "mnemonic: \"$(stoml "${HOME_DIR}/key_seed.json" secret)\""
       elif [ -f "${HOME_DIR}/${KEY_NAME}_seed.json" ]; then
         echo "mnemonic: \"$(stoml "${HOME_DIR}/${KEY_NAME}_seed.json" mnemonic)\""
+      elif a_in_b "${KEY_NAME%%n0}" "$FULL_NODES"; then
+        echo "mnemonic: \"$(stoml "${HOME_DIR}/key_seed.json" secret)\""
       else
         echo "mnemonic: \"\""
       fi
@@ -1345,7 +1345,7 @@ create_wallet() {
     # If the key file does not exist, we will create a new key.
     else
       if [ -z "${HDPATH}" ]; then
-        if ! "${GAIAD_BINARY}" keys add "$1" --keyring-backend test --home "${NETWORK_HOME_DIR}" --output json 1> "${NETWORK_HOME_DIR}/${1}_seed.json" 2>&1 1>/dev/null; then
+        if ! "${GAIAD_BINARY}" keys add "$1" --keyring-backend test --home "${NETWORK_HOME_DIR}" --output json 1> "${NETWORK_HOME_DIR}/${1}_seed.json" 2>&1; then
           warn "could not create key '${1}' on network '${NETWORK}'"
           shift
           continue
@@ -1353,7 +1353,7 @@ create_wallet() {
           info "created key '${1}' on network '${NETWORK}'"
         fi
       else
-        if ! "${GAIAD_BINARY}" keys add "$1" --hd-path "$HDPATH" --keyring-backend test --home "${NETWORK_HOME_DIR}" --output json 1> "${NETWORK_HOME_DIR}/${1}_seed.json" 2>&1 1>/dev/null; then
+        if ! "${GAIAD_BINARY}" keys add "$1" --hd-path "$HDPATH" --keyring-backend test --home "${NETWORK_HOME_DIR}" --output json 1> "${NETWORK_HOME_DIR}/${1}_seed.json" 2>&1; then
           warn "could not create key '${1}' on network '${NETWORK}'"
           shift
           continue


### PR DESCRIPTION
## v0.1.6

### BUGFIXES

- Documented `create-validator` in the help section.
- When using `create-validator the seed phrase for the validator wallet was not saved.
- When listing keys that were created using `create-validator`, the validator's key was not found 
  because it was considered a full node first and full nodes store keys in key_seed.json, not <name>_seed.json.
