### PR TITLE
More reliable check for presence of `genesis` vs `gentx` commands

### DIFF
--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -514,21 +514,8 @@ get_sdk_version() {
 }
 
 get_genesis_cmd_prefix() {
-    GENESIS_BREAKING_VERSION="0.47.0"
-    SDK_VERSION="$(get_sdk_version "$1")"
-    RESULT=""
-    if [ -z "$SDK_VERSION" ]; then
-      # Handle the sdk version error here, happens when --long is not supported
-      GAIAD_BINARY="$(get_gaiad_binary "$1")"
-      RESULT="$($GAIAD_BINARY | grep -q 'gentx' || echo "genesis")"
-    else
-      HIGHER_VERSION=$(echo "${GENESIS_BREAKING_VERSION}\n${SDK_VERSION}" | sort -Vr | sed -n '1p')
-      if [ "$HIGHER_VERSION" = "$SDK_VERSION" ]; then
-        # Perform actions for the >= 0.47.0 case here
-        RESULT="genesis"
-      fi
-    fi
-    echo "$RESULT"
+  GAIAD_BINARY="$(get_gaiad_binary "$1")"
+  RESULT="$($GAIAD_BINARY | grep -q 'gentx' || echo "genesis")"
 }
 
 get_add_to_hermes() {

--- a/bin/lib-gm
+++ b/bin/lib-gm
@@ -516,6 +516,7 @@ get_sdk_version() {
 get_genesis_cmd_prefix() {
   GAIAD_BINARY="$(get_gaiad_binary "$1")"
   RESULT="$($GAIAD_BINARY | grep -q 'gentx' || echo "genesis")"
+  echo "$RESULT"
 }
 
 get_add_to_hermes() {


### PR DESCRIPTION
Some chain binaries, such as `simd` v7, are running SDK 0.47+ but do not expose a `genesis` command, therefore the version-based check incorrectly assumes the command to use to be `genesis` instead of `gentx` for those chains.

Simply checking if the `gentx` command is present or not is more reliable.

```
❯ simd version
v7.2.0

❯ simd version --long | rg cosmos_sdk_version
cosmos_sdk_version: v0.47.3

❯ simd | rg gentx
  collect-gentxs      Collect genesis txs and output a genesis.json file
  gentx               Generate a genesis tx carrying a self delegation

❯ simd genesis
Error: unknown command "genesis" for "simd"
Run 'simd --help' for usage.
```